### PR TITLE
Allow modifier key click

### DIFF
--- a/wooswipe.js
+++ b/wooswipe.js
@@ -101,6 +101,10 @@
     // click event
     if ($('.single-product-main-image').length > 0) {
       $('.single-product-main-image').click(function(e) {
+        // Allow user to open image link in new tab or download it
+        if (e.which == 2 || e.ctrlKey || e.altKey) {
+          return;
+        }
         var ind = $(this).find('img').attr('data-ind');
         e.preventDefault();
         var index = ind ? parseInt(ind) : 0;


### PR DESCRIPTION
Allow user to open image link in new tab or download it by restoring the default functionality to middle-click, Ctrl-click and Alt-click.