### PR TITLE
Automate WordPress.org plugin releases

### DIFF
--- a/.github/workflows/deploy-wordpress.yml
+++ b/.github/workflows/deploy-wordpress.yml
@@ -1,0 +1,23 @@
+name: Deploy to WordPress.org
+
+on:
+  push:
+    tags:
+      - "*"
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy tagged release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out plugin
+        uses: actions/checkout@v4
+
+      - name: Deploy to WordPress.org
+        uses: 10up/action-wordpress-plugin-deploy@stable
+        env:
+          SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+          SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}

--- a/wooswipe.php
+++ b/wooswipe.php
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'WOOSWIPE_VERSION', '3.0.1' );
+define( 'WOOSWIPE_VERSION', '3.0.8' );
 
 /**
  * The code that runs during plugin activation.


### PR DESCRIPTION
Adds a GitHub Actions workflow that deploys tagged releases to the WordPress.org `wooswipe` SVN repository. Also corrects the internal `WOOSWIPE_VERSION` constant from `3.0.1` to `3.0.8` so it matches the plugin header and stable tag.

Before publishing the next release, add the repository secrets `SVN_USERNAME` and `SVN_PASSWORD`.