### PR TITLE
Add safe dry runs for WordPress.org deployment

### DIFF
--- a/.github/workflows/deploy-wordpress.yml
+++ b/.github/workflows/deploy-wordpress.yml
@@ -1,6 +1,8 @@
 name: Deploy to WordPress.org
 
 on:
+  pull_request:
+  workflow_dispatch:
   push:
     tags:
       - "*"
@@ -10,14 +12,16 @@ permissions:
 
 jobs:
   deploy:
-    name: Deploy tagged release
+    name: Validate or deploy plugin
     runs-on: ubuntu-latest
     steps:
       - name: Check out plugin
         uses: actions/checkout@v4
 
-      - name: Deploy to WordPress.org
+      - name: Validate or deploy to WordPress.org
         uses: 10up/action-wordpress-plugin-deploy@stable
+        with:
+          dry-run: ${{ github.event_name != 'push' }}
         env:
-          SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
-          SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+          SVN_USERNAME: ${{ github.event_name == 'push' && secrets.SVN_USERNAME || '' }}
+          SVN_PASSWORD: ${{ github.event_name == 'push' && secrets.SVN_PASSWORD || '' }}

--- a/.github/workflows/deploy-wordpress.yml
+++ b/.github/workflows/deploy-wordpress.yml
@@ -23,5 +23,5 @@ jobs:
         with:
           dry-run: ${{ github.event_name != 'push' }}
         env:
-          SVN_USERNAME: ${{ github.event_name == 'push' && secrets.SVN_USERNAME || '' }}
-          SVN_PASSWORD: ${{ github.event_name == 'push' && secrets.SVN_PASSWORD || '' }}
+          SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+          SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}

--- a/.github/workflows/deploy-wordpress.yml
+++ b/.github/workflows/deploy-wordpress.yml
@@ -23,5 +23,6 @@ jobs:
         with:
           dry-run: ${{ github.event_name != 'push' }}
         env:
+          VERSION: ${{ github.event_name == 'push' && github.ref_name || '3.0.9-test' }}
           SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
           SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}


### PR DESCRIPTION
Adds a non-publishing dry run for pull requests and manual workflow runs. Tag pushes remain the only event that publishes to WordPress.org.

This pull request should trigger the first packaging test without changing the live WordPress.org plugin.